### PR TITLE
Feature/get build actions

### DIFF
--- a/src/main/java/com/cdancy/jenkins/rest/domain/job/Action.java
+++ b/src/main/java/com/cdancy/jenkins/rest/domain/job/Action.java
@@ -1,7 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.cdancy.jenkins.rest.domain.job;
 
-/**
- * Created by rbindra on 7/18/18.
- */
-public class Action {
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
+import org.jclouds.json.SerializedNames;
+
+import java.util.List;
+
+@AutoValue
+public abstract class Action {
+
+    public abstract List<Cause> causes();
+
+    public abstract List<Parameter> parameters();
+
+    Action() {
+    }
+
+    @SerializedNames({"causes", "parameters"})
+    public static Action create(List<Cause> causes, List<Parameter> parameters) {
+        return new AutoValue_Action(
+            causes != null ? ImmutableList.copyOf(causes) : ImmutableList.<Cause>of(),
+            parameters != null ? ImmutableList.copyOf(parameters) : ImmutableList.<Parameter>of());
+    }
 }
+

--- a/src/main/java/com/cdancy/jenkins/rest/domain/job/Action.java
+++ b/src/main/java/com/cdancy/jenkins/rest/domain/job/Action.java
@@ -1,0 +1,7 @@
+package com.cdancy.jenkins.rest.domain.job;
+
+/**
+ * Created by rbindra on 7/18/18.
+ */
+public class Action {
+}

--- a/src/main/java/com/cdancy/jenkins/rest/domain/job/BuildInfo.java
+++ b/src/main/java/com/cdancy/jenkins/rest/domain/job/BuildInfo.java
@@ -30,6 +30,8 @@ public abstract class BuildInfo {
 
    public abstract List<Artifact> artifacts();
 
+   public abstract List<Action> actions();
+
    public abstract boolean building();
 
    @Nullable
@@ -70,14 +72,16 @@ public abstract class BuildInfo {
    BuildInfo() {
    }
 
-   @SerializedNames({ "artifacts", "building", "description", "displayName", "duration", "estimatedDuration",
+   @SerializedNames({ "artifacts", "actions", "building", "description", "displayName", "duration", "estimatedDuration",
          "fullDisplayName", "id", "keepLog", "number", "queueId", "result", "timestamp", "url", "builtOn", "culprits" })
-   public static BuildInfo create(List<Artifact> artifacts, boolean building, String description, String displayName,
+   public static BuildInfo create(List<Artifact> artifacts, List<Action> actions, boolean building, String description, String displayName,
          long duration, long estimatedDuration, String fullDisplayName, String id, boolean keepLog, int number,
          int queueId, String result, long timestamp, String url, String builtOn, List<Culprit> culprits) {
       return new AutoValue_BuildInfo(
-            artifacts != null ? ImmutableList.copyOf(artifacts) : ImmutableList.<Artifact> of(), building, description,
-            displayName, duration, estimatedDuration, fullDisplayName, id, keepLog, number, queueId, result, timestamp,
-            url, builtOn, culprits != null ? ImmutableList.copyOf(culprits) : ImmutableList.<Culprit> of());
+            artifacts != null ? ImmutableList.copyOf(artifacts) : ImmutableList.<Artifact> of(),
+            actions != null ? ImmutableList.copyOf(actions) : ImmutableList.<Action> of(),
+            building, description, displayName, duration, estimatedDuration, fullDisplayName,
+            id, keepLog, number, queueId, result, timestamp, url, builtOn,
+            culprits != null ? ImmutableList.copyOf(culprits) : ImmutableList.<Culprit> of());
    }
 }

--- a/src/main/java/com/cdancy/jenkins/rest/domain/job/Cause.java
+++ b/src/main/java/com/cdancy/jenkins/rest/domain/job/Cause.java
@@ -1,7 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.cdancy.jenkins.rest.domain.job;
 
-/**
- * Created by rbindra on 7/18/18.
- */
-public class Cause {
+import com.google.auto.value.AutoValue;
+import org.jclouds.javax.annotation.Nullable;
+import org.jclouds.json.SerializedNames;
+
+@AutoValue
+public abstract class Cause {
+
+    public abstract String shortDescription();
+
+    @Nullable
+    public abstract String userId();
+
+    public abstract String userName();
+
+    Cause() {
+    }
+
+    @SerializedNames({ "shortDescription", "userId", "userName"})
+    public static Cause create(String shortDescription, String userId, String userName) {
+        return new AutoValue_Cause(shortDescription, userId, userName);
+    }
 }

--- a/src/main/java/com/cdancy/jenkins/rest/domain/job/Cause.java
+++ b/src/main/java/com/cdancy/jenkins/rest/domain/job/Cause.java
@@ -1,0 +1,7 @@
+package com.cdancy.jenkins.rest.domain.job;
+
+/**
+ * Created by rbindra on 7/18/18.
+ */
+public class Cause {
+}

--- a/src/main/java/com/cdancy/jenkins/rest/domain/job/Cause.java
+++ b/src/main/java/com/cdancy/jenkins/rest/domain/job/Cause.java
@@ -29,6 +29,7 @@ public abstract class Cause {
     @Nullable
     public abstract String userId();
 
+    @Nullable
     public abstract String userName();
 
     Cause() {

--- a/src/main/java/com/cdancy/jenkins/rest/domain/job/Parameter.java
+++ b/src/main/java/com/cdancy/jenkins/rest/domain/job/Parameter.java
@@ -1,7 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.cdancy.jenkins.rest.domain.job;
 
-/**
- * Created by rbindra on 7/18/18.
- */
-public class Parameter {
+import com.google.auto.value.AutoValue;
+import org.jclouds.javax.annotation.Nullable;
+import org.jclouds.json.SerializedNames;
+
+@AutoValue
+public abstract class Parameter {
+
+    public abstract String name();
+
+    @Nullable
+    public abstract String value();
+
+    Parameter() {
+    }
+
+    @SerializedNames({"name", "value"})
+    public static Parameter create(String name, String value) {
+        return new AutoValue_Parameter(name, value);
+    }
 }

--- a/src/main/java/com/cdancy/jenkins/rest/domain/job/Parameter.java
+++ b/src/main/java/com/cdancy/jenkins/rest/domain/job/Parameter.java
@@ -1,0 +1,7 @@
+package com.cdancy.jenkins.rest.domain.job;
+
+/**
+ * Created by rbindra on 7/18/18.
+ */
+public class Parameter {
+}

--- a/src/test/java/com/cdancy/jenkins/rest/features/JobsApiMockTest.java
+++ b/src/test/java/com/cdancy/jenkins/rest/features/JobsApiMockTest.java
@@ -27,6 +27,9 @@ import java.util.Map;
 
 import javax.ws.rs.core.MediaType;
 
+import com.cdancy.jenkins.rest.domain.job.Action;
+import com.cdancy.jenkins.rest.domain.job.Cause;
+import com.cdancy.jenkins.rest.domain.job.Parameter;
 import org.testng.annotations.Test;
 
 import com.cdancy.jenkins.rest.JenkinsApi;
@@ -530,6 +533,64 @@ public class JobsApiMockTest extends BaseJenkinsMockTest {
             assertTrue(output.errors().get(0).exceptionName().equals("org.jclouds.rest.ResourceNotFoundException"));
             assertNotNull(output.errors().get(0).context());
             assertSentAccept(server, "POST", "/job/DevTest/buildWithParameters", "application/unknown");
+        } finally {
+            jenkinsApi.close();
+            server.shutdown();
+        }
+    }
+
+    public void testGetParams() throws Exception {
+        MockWebServer server = mockWebServer();
+
+        String body = payloadFromResource("/build-info.json");
+        server.enqueue(new MockResponse().setBody(body).setResponseCode(200));
+        JenkinsApi jenkinsApi = api(server.getUrl("/"));
+        JobsApi api = jenkinsApi.jobsApi();
+        try {
+            List<Parameter> output = api.buildInfo(null,"fish", 10).actions().get(0).parameters();
+            assertNotNull(output);
+            assertTrue(output.get(0).name().equals("bear"));
+            assertTrue(output.get(0).value().equals("true"));
+            assertTrue(output.get(1).name().equals("fish"));
+            assertTrue(output.get(1).value().equals("salmon"));
+            assertSent(server, "GET", "/job/fish/10/api/json");
+        } finally {
+            jenkinsApi.close();
+            server.shutdown();
+        }
+    }
+
+    public void testGetParamsWhenNoBuildParams() throws Exception {
+        MockWebServer server = mockWebServer();
+
+        String body = payloadFromResource("/build-info-no-params.json");
+        server.enqueue(new MockResponse().setBody(body).setResponseCode(200));
+        JenkinsApi jenkinsApi = api(server.getUrl("/"));
+        JobsApi api = jenkinsApi.jobsApi();
+        try {
+            List<Parameter> output = api.buildInfo(null,"fish", 10).actions().get(0).parameters();
+            assertTrue(output.size() == 0);
+            assertSent(server, "GET", "/job/fish/10/api/json");
+        } finally {
+            jenkinsApi.close();
+            server.shutdown();
+        }
+    }
+
+    public void testGetCause() throws Exception {
+        MockWebServer server = mockWebServer();
+
+        String body = payloadFromResource("/build-info-no-params.json");
+        server.enqueue(new MockResponse().setBody(body).setResponseCode(200));
+        JenkinsApi jenkinsApi = api(server.getUrl("/"));
+        JobsApi api = jenkinsApi.jobsApi();
+        try {
+            List<Cause> output = api.buildInfo(null,"fish", 10).actions().get(0).causes();
+            assertNotNull(output);
+            assertTrue(output.get(0).shortDescription().equals("Started by user anonymous"));
+            assertNull(output.get(0).userId());
+            assertTrue(output.get(0).userName().equals("anonymous"));
+            assertSent(server, "GET", "/job/fish/10/api/json");
         } finally {
             jenkinsApi.close();
             server.shutdown();

--- a/src/test/resources/build-info-no-params.json
+++ b/src/test/resources/build-info-no-params.json
@@ -1,0 +1,70 @@
+{
+  "_class" : "org.jenkinsci.plugins.workflow.job.WorkflowRun",
+  "actions" : [
+    {
+      "_class" : "hudson.model.CauseAction",
+      "causes" : [
+        {
+          "_class" : "hudson.model.Cause$UserIdCause",
+          "shortDescription" : "Started by user anonymous",
+          "userId" : null,
+          "userName" : "anonymous"
+        }
+      ]
+    },
+    {
+      "_class" : "jenkins.metrics.impl.TimeInQueueAction"
+    },
+    {
+
+    },
+    {
+
+    },
+    {
+
+    },
+    {
+
+    },
+    {
+      "_class" : "org.jenkinsci.plugins.workflow.job.views.FlowGraphAction"
+    },
+    {
+
+    },
+    {
+
+    }
+  ],
+  "artifacts" : [
+
+  ],
+  "building" : false,
+  "description" : null,
+  "displayName" : "#10",
+  "duration" : 60750,
+  "estimatedDuration" : 60258,
+  "executor" : null,
+  "fullDisplayName" : "fish #10",
+  "id" : "10",
+  "keepLog" : false,
+  "number" : 10,
+  "queueId" : 73,
+  "result" : "SUCCESS",
+  "timestamp" : 1461091892486,
+  "url" : "http://localhost:32769/job/fish/10/",
+  "builtOn" : "",
+  "changeSet" : {
+    "items" : [
+
+    ],
+    "kind" : null
+  },
+  "culprits" : [
+    {
+      "absoluteUrl": "http://localhost:8080/user/username",
+      "fullName": "username"
+    }
+  ]
+}


### PR DESCRIPTION
We need to access build parameters of the job. This is required for our feature that if we trigger a pull request, we need to check if the same build is already running. The job rest api returns the "actions" object, which contains parameters and causes, which I was unable to find in jenkins-rest. 

So, I added the actions api in BuildInfo class, which returns a list of actions. Each action object can be used to retrieve parameters objects. I added the Parameters and Causes class for the same.

This is an initial implementation of the change along with the mock tests. 